### PR TITLE
Add optional flag for processing small PDF batches

### DIFF
--- a/backend/etl/config.dev.yaml
+++ b/backend/etl/config.dev.yaml
@@ -13,6 +13,7 @@
 file_processing:
   ocr:
     default_model: "unstructured"
+    max_pdfs: 10
 
     unstructured:
       strategy: "fast"          # pdfminer text extraction only, no ML models

--- a/backend/etl/config.yaml
+++ b/backend/etl/config.yaml
@@ -47,6 +47,7 @@ file_processing:
     max_concurrent: 4
     min_chars_per_page: 100
     max_pages: 250            # Skip PDFs longer than this (0 = no limit)
+    max_pdfs: null            # Maximum PDFs to process (null = all, override with --max-pdfs CLI flag)
 
     marker:
       force_ocr: true

--- a/backend/etl/scripts/run_pdf_processor.py
+++ b/backend/etl/scripts/run_pdf_processor.py
@@ -75,6 +75,15 @@ def main():
     parser.add_argument(
         "--no-progress", action="store_true", help="Disable progress display"
     )
+    parser.add_argument(
+        "--max-pdfs",
+        type=int,
+        default=None,
+        help=(
+            "Maximum number of PDFs to process (default: None = all PDFs). "
+            "Overrides file_processing.ocr.max_pdfs from config when provided."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -91,6 +100,8 @@ def main():
         storage=storage,
         force_reprocess=args.force_reprocess,
         config_path=Path(args.config) if args.config else None,
+        max_pdfs=args.max_pdfs,
+        show_progress=not args.no_progress,
     )
 
     # Generate summary


### PR DESCRIPTION
This pull request introduces a configurable limit on the number of PDFs processed by the ETL pipeline, allowing users to set this limit via both configuration files and a command-line argument. The main changes add support for a new `max_pdfs` parameter, ensure proper precedence between CLI and config values, and update documentation and logging for clarity.