### PR TITLE
Document Tagging Stage for ETL Pipeline

### DIFF
--- a/backend/etl/config.dev.yaml
+++ b/backend/etl/config.dev.yaml
@@ -13,6 +13,7 @@
 file_processing:
   ocr:
     default_model: "unstructured"
+    max_pdfs: 10
 
     unstructured:
       strategy: "fast"          # pdfminer text extraction only, no ML models

--- a/backend/etl/config.dev.yaml
+++ b/backend/etl/config.dev.yaml
@@ -30,3 +30,6 @@ file_processing:
     chunk_size: 100                  # ~100 tokens — safe for 256 token limit
     chunk_overlap: 20
     max_chunk_size: 200              # Hard cap: clamped to min(200, 256-100) = 156
+
+  tagging:
+    max_docs: 10                     # Limit tagging to 10 documents in dev mode

--- a/backend/etl/config.yaml
+++ b/backend/etl/config.yaml
@@ -92,7 +92,50 @@ file_processing:
       - "^#{1,6}\\s+"              # markdown headers
       - "^\\d+\\.\\s+"             # numbered lists
       - "^[A-Z][A-Z\\s]+:"         # section labels like "INTRODUCTION:"
-
+  tagging:
+    enabled: true
+    abstract_min_length: 100       # chars; below this, fall back to chunk sampling
+    num_fallback_chunks: 3         # number of chunks to sample when abstract is missing
+    llm:
+      provider: "openai"           # Options: openai, openrouter
+      model: "gpt-4o-mini"
+      temperature: 0.1
+      max_tokens: 500
+    taxonomy:
+      regions:
+        - "Latin America"
+        - "Sub-Saharan Africa"
+        - "East Asia"
+        - "South Asia"
+        - "Middle East & North Africa"
+        - "Eastern Europe & Central Asia"
+        - "Global / Cross-regional"
+      topics:
+        - "economic complexity"
+        - "growth diagnostics"
+        - "trade policy"
+        - "labor markets"
+        - "fiscal policy"
+        - "industrial policy"
+        - "migration"
+        - "education"
+        - "energy"
+        - "agriculture"
+        - "financial markets"
+        - "institutions & governance"
+      document_type:
+        - "working paper"
+        - "policy brief"
+        - "report"
+        - "book chapter"
+        - "journal article"
+        - "lecture"
+      methodology:
+        - "empirical"
+        - "theoretical"
+        - "case study"
+        - "mixed methods"
+        - "data analysis"
 # Storage
 storage:
   vector_db:

--- a/backend/etl/config.yaml
+++ b/backend/etl/config.yaml
@@ -47,6 +47,7 @@ file_processing:
     max_concurrent: 4
     min_chars_per_page: 100
     max_pages: 250            # Skip PDFs longer than this (0 = no limit)
+    max_pdfs: null            # Maximum PDFs to process (null = all, override with --max-pdfs CLI flag)
 
     marker:
       force_ocr: true

--- a/backend/etl/scripts/run_document_tagger.py
+++ b/backend/etl/scripts/run_document_tagger.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+"""
+Script to run the document tagger for Growth Lab publications.
+
+Reads processed chunks, generates structured metadata tags via LLM (using
+title + abstract from the tracker, falling back to chunk sampling), and
+injects the tags into each chunk's metadata for downstream Qdrant filtering.
+
+Pipeline position: after run_text_chunker.py, before run_embeddings_generator.py.
+
+Usage:
+    uv run python backend/etl/scripts/run_document_tagger.py --config backend/etl/config.dev.yaml
+    uv run python backend/etl/scripts/run_document_tagger.py --config backend/etl/config.yaml --max-docs 5
+"""
+
+import argparse
+import asyncio
+import logging
+import sys
+
+from dotenv import load_dotenv
+from loguru import logger
+
+from backend.etl.models.tracking import TaggingStatus
+from backend.etl.utils.document_tagger import DocumentTagger
+from backend.storage.factory import get_storage
+
+
+class InterceptHandler(logging.Handler):
+    """Redirect standard logging to loguru."""
+
+    def emit(self, record):
+        try:
+            level = logger.level(record.levelname).name
+        except ValueError:
+            level = record.levelno
+        frame, depth = logging.currentframe(), 2
+        while frame.f_code.co_filename == logging.__file__:
+            frame = frame.f_back
+            depth += 1
+        logger.opt(depth=depth, exception=record.exc_info).log(
+            level, record.getMessage()
+        )
+
+
+def setup_logging():
+    """Configure loguru for console output."""
+    logger.remove()
+    logger.add(
+        sys.stderr,
+        level="INFO",
+        format=(
+            "<green>{time:YYYY-MM-DD HH:mm:ss}</green> | "
+            "<level>{level: <8}</level> | "
+            "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - "
+            "<level>{message}</level>"
+        ),
+    )
+    logging.basicConfig(handlers=[InterceptHandler()], level=0, force=True)
+
+
+async def async_main(args: argparse.Namespace) -> int:
+    """Async entry point."""
+    storage = get_storage(config_path=args.config, storage_type=args.storage_type)
+
+    # Try to load the tracker; degrade gracefully if unavailable
+    tracker = None
+    try:
+        from backend.etl.utils.publication_tracker import PublicationTracker
+
+        tracker = PublicationTracker()
+    except Exception as e:
+        logger.warning(
+            f"Could not initialise PublicationTracker: {e}. "
+            "Continuing without tracker (tags won't be written to SQLite)."
+        )
+
+    logger.info("Starting document tagging")
+
+    tagger = DocumentTagger(config_path=args.config, tracker=tracker)
+    results = await tagger.process_all_documents(
+        storage=storage,
+        max_docs=args.max_docs,
+        overwrite=args.overwrite,
+    )
+
+    total = len(results)
+    if total == 0:
+        logger.warning(
+            "No documents were tagged — nothing to process or all already tagged"
+        )
+        return 0
+
+    successful = sum(1 for r in results if r.status == TaggingStatus.TAGGED)
+    failed = sum(1 for r in results if r.status == TaggingStatus.FAILED)
+    total_chunks = sum(r.chunks_tagged for r in results)
+    total_time = sum(r.processing_time for r in results)
+    abstract_used = sum(1 for r in results if r.text_source == "abstract")
+    chunks_used = sum(1 for r in results if r.text_source == "chunks")
+
+    logger.info("=" * 60)
+    logger.info("Document Tagging Summary")
+    logger.info("=" * 60)
+    logger.info(f"Documents processed:   {total}")
+    logger.info(f"  Successful:          {successful}")
+    logger.info(f"  Failed:              {failed}")
+    logger.info(f"Total chunks tagged:   {total_chunks}")
+    logger.info(
+        f"Text source — abstract: {abstract_used}, chunk samples: {chunks_used}"
+    )
+    logger.info(f"Total processing time: {total_time:.2f}s")
+
+    if failed > 0:
+        logger.warning("Failed documents:")
+        for r in results:
+            if r.status == TaggingStatus.FAILED:
+                logger.warning(f"  - {r.publication_id}: {r.error_message}")
+
+    return 0 if failed == 0 else 1
+
+
+def main():
+    """CLI entry point."""
+    load_dotenv()
+    parser = argparse.ArgumentParser(
+        description=(
+            "Tag processed document chunks with structured metadata "
+            "using an LLM for downstream Qdrant payload filtering."
+        )
+    )
+    parser.add_argument(
+        "--config",
+        type=str,
+        default="backend/etl/config.yaml",
+        help="Path to configuration file (default: backend/etl/config.yaml)",
+    )
+    parser.add_argument(
+        "--storage-type",
+        type=str,
+        choices=["local", "cloud"],
+        help="Storage type to use",
+    )
+    parser.add_argument(
+        "--max-docs",
+        type=int,
+        default=None,
+        help=(
+            "Maximum number of documents to tag. "
+            "Overrides file_processing.tagging.max_docs from config when provided."
+        ),
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help=(
+            "Re-tag documents that have already been tagged, "
+            "overwriting existing document_tags in chunks.json."
+        ),
+    )
+
+    args = parser.parse_args()
+    setup_logging()
+    return asyncio.run(async_main(args))
+
+
+if __name__ == "__main__":
+    try:
+        exit_code = main()
+        sys.exit(exit_code)
+    except KeyboardInterrupt:
+        logger.warning("Process interrupted by user")
+        sys.exit(130)
+    except Exception as e:
+        logger.exception(f"Error running document tagger: {e}")
+        sys.exit(1)

--- a/backend/etl/scripts/run_pdf_processor.py
+++ b/backend/etl/scripts/run_pdf_processor.py
@@ -75,6 +75,15 @@ def main():
     parser.add_argument(
         "--no-progress", action="store_true", help="Disable progress display"
     )
+    parser.add_argument(
+        "--max-pdfs",
+        type=int,
+        default=None,
+        help=(
+            "Maximum number of PDFs to process (default: None = all PDFs). "
+            "Overrides file_processing.ocr.max_pdfs from config when provided."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -91,6 +100,8 @@ def main():
         storage=storage,
         force_reprocess=args.force_reprocess,
         config_path=Path(args.config) if args.config else None,
+        max_pdfs=args.max_pdfs,
+        show_progress=not args.no_progress,
     )
 
     # Generate summary

--- a/backend/etl/utils/document_tagger.py
+++ b/backend/etl/utils/document_tagger.py
@@ -1,0 +1,478 @@
+"""
+Document tagging module for Growth Lab Deep Search ETL pipeline.
+
+Generates structured metadata tags for documents using an LLM and propagates
+them to all chunks produced from each document.  Tags are stored both in the
+PublicationTracking SQLite database and inside each chunk's ``metadata`` dict
+as ``document_tags``, making them available as Qdrant payload filters.
+
+Pipeline position: after text chunker, before embeddings generator.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+from openai import AsyncOpenAI
+from pydantic import BaseModel
+
+from backend.etl.models.tracking import TaggingStatus
+from backend.storage.base import StorageBase
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TaggingResult:
+    """Result of the tagging operation for a single document."""
+
+    publication_id: str
+    status: TaggingStatus
+    tags: dict[str, Any] | None
+    processing_time: float
+    chunks_tagged: int = 0
+    text_source: str = "abstract"  # "abstract", "chunks", or "none"
+    error_message: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Pydantic output schema
+# ---------------------------------------------------------------------------
+
+
+class DocumentTags(BaseModel):
+    """Structured output schema enforcing the four required tag fields."""
+
+    regions: list[str]
+    topics: list[str]
+    document_type: str
+    methodology: list[str]
+
+
+# ---------------------------------------------------------------------------
+# Prompt template
+# ---------------------------------------------------------------------------
+
+_PROMPT_TEMPLATE = """\
+You are a research document classifier for the Harvard Growth Lab publication library.
+
+Given the following document information, classify it using the provided taxonomy.
+{title_section}
+{text_section}
+
+## Taxonomy
+Select ALL that apply from each category. You may add at most ONE new entry per \
+category if nothing in the provided list fits.
+
+regions (countries or world regions the document focuses on):
+{regions}
+
+topics (research themes covered):
+{topics}
+
+document_type (pick EXACTLY ONE best match):
+{document_types}
+
+methodology (research approaches used):
+{methodologies}
+
+## Instructions
+- Choose all relevant items from each category.
+- For document_type, select exactly one value (a string, not a list).
+- Use ONLY values from the provided taxonomy lists above (you may add at most one \
+new entry per category if nothing provided fits).
+- Return values as arrays for regions, topics, and methodology; a single string \
+for document_type."""
+
+
+# ---------------------------------------------------------------------------
+# DocumentTagger
+# ---------------------------------------------------------------------------
+
+
+class DocumentTagger:
+    """Tags documents with structured metadata using an LLM.
+
+    Reads publication title/abstract from the tracker (falls back to chunk
+    sampling when the abstract is absent or too short), calls an LLM to
+    classify the document against a configured taxonomy, and writes the
+    resulting tag dict into every chunk's ``metadata["document_tags"]`` field.
+
+    Tags are also persisted to the PublicationTracking SQLite table via the
+    optional ``tracker`` dependency.
+    """
+
+    def __init__(
+        self,
+        config_path: str | Path | None = None,
+        tracker=None,
+    ) -> None:
+        self.tracker = tracker
+        self._full_config = self._load_config(config_path)
+        self.config: dict = (
+            self._full_config.get("file_processing", {}).get("tagging", {})
+        )
+
+        self.abstract_min_length: int = self.config.get("abstract_min_length", 100)
+        self.num_fallback_chunks: int = self.config.get("num_fallback_chunks", 3)
+
+        llm_cfg = self.config.get("llm", {})
+        self.llm_model: str = llm_cfg.get("model", "gpt-4o-mini")
+        self.llm_temperature: float = llm_cfg.get("temperature", 0.1)
+        self.llm_max_tokens: int = llm_cfg.get("max_tokens", 500)
+
+        provider = llm_cfg.get("provider", "openai")
+        llm_base_url: str | None = (
+            "https://openrouter.ai/api/v1" if provider == "openrouter" else None
+        )
+        api_key: str | None = llm_cfg.get("api_key", os.environ.get("OPENAI_API_KEY"))
+        self._client = AsyncOpenAI(api_key=api_key, base_url=llm_base_url)
+
+        taxonomy = self.config.get("taxonomy", {})
+        self.taxonomy_regions: list[str] = taxonomy.get("regions", [])
+        self.taxonomy_topics: list[str] = taxonomy.get("topics", [])
+        self.taxonomy_doc_types: list[str] = taxonomy.get("document_type", [])
+        self.taxonomy_methodologies: list[str] = taxonomy.get("methodology", [])
+
+    # ------------------------------------------------------------------
+    # Config loading
+    # ------------------------------------------------------------------
+
+    def _load_config(self, config_path: str | Path | None) -> dict:
+        """Load full config from YAML."""
+        if not config_path:
+            config_path = Path(__file__).parent.parent / "config.yaml"
+        config_path = Path(config_path)
+        try:
+            with open(config_path) as f:
+                return yaml.safe_load(f) or {}
+        except Exception as e:
+            logger.warning(f"Error loading tagger config from {config_path}: {e}")
+            return {}
+
+    # ------------------------------------------------------------------
+    # Prompt construction
+    # ------------------------------------------------------------------
+
+    def _build_prompt(self, title: str | None, text: str) -> str:
+        """Build the LLM classification prompt."""
+        title_section = f"Title: {title}" if title else ""
+        text_section = f"Abstract / Text:\n{text}"
+        return _PROMPT_TEMPLATE.format(
+            title_section=title_section,
+            text_section=text_section,
+            regions="\n".join(f"  - {r}" for r in self.taxonomy_regions),
+            topics="\n".join(f"  - {t}" for t in self.taxonomy_topics),
+            document_types="\n".join(f"  - {d}" for d in self.taxonomy_doc_types),
+            methodologies="\n".join(f"  - {m}" for m in self.taxonomy_methodologies),
+        )
+
+    # ------------------------------------------------------------------
+    # LLM call
+    # ------------------------------------------------------------------
+
+    async def _call_llm(self, prompt: str) -> dict[str, Any] | None:
+        """Call the LLM using Pydantic structured outputs, or None after 3 failures."""
+        for attempt in range(3):
+            try:
+                response = await self._client.beta.chat.completions.parse(
+                    model=self.llm_model,
+                    temperature=self.llm_temperature,
+                    max_tokens=self.llm_max_tokens,
+                    response_format=DocumentTags,
+                    messages=[{"role": "user", "content": prompt}],
+                )
+                parsed: DocumentTags | None = response.choices[0].message.parsed
+                if parsed is None:
+                    raise ValueError("LLM refused to generate structured output")
+                return parsed.model_dump()
+
+            except Exception as e:
+                logger.warning(f"LLM call error (attempt {attempt + 1}/3): {e}")
+                if attempt < 2:
+                    await asyncio.sleep(2**attempt)
+
+        return None
+
+    # ------------------------------------------------------------------
+    # Text input resolution
+    # ------------------------------------------------------------------
+
+    def _get_text_input(
+        self, pub_id: str, chunks_path: Path
+    ) -> tuple[str | None, str, str]:
+        """Resolve the text that will be sent to the LLM.
+
+        Priority:
+        1. Abstract from the tracker (if length >= abstract_min_length).
+        2. Sample of representative chunks from the chunks.json file.
+
+        Returns:
+            (title, text, source) where source is "abstract", "chunks", or "none".
+        """
+        title: str | None = None
+        abstract: str | None = None
+
+        if self.tracker:
+            try:
+                pub = self.tracker.get_publication(pub_id)
+                if pub:
+                    title = pub.title
+                    abstract = pub.abstract
+            except Exception as e:
+                logger.debug(
+                    f"Could not fetch tracker record for {pub_id}: {e}"
+                )
+
+        if abstract and len(abstract) >= self.abstract_min_length:
+            return title, abstract, "abstract"
+
+        # Fallback: sample first, middle, and last chunks
+        try:
+            with open(chunks_path, encoding="utf-8") as f:
+                chunks = json.load(f)
+            if not chunks:
+                return title, abstract or "", "none"
+            n = len(chunks)
+            indices = sorted({0, n // 2, n - 1})[: self.num_fallback_chunks]
+            sampled_text = "\n\n---\n\n".join(
+                chunks[i]["text_content"] for i in indices if i < n
+            )
+            return title, sampled_text, "chunks"
+        except Exception as e:
+            logger.warning(f"Could not sample chunks for {pub_id}: {e}")
+
+        return title, abstract or "", "none"
+
+    # ------------------------------------------------------------------
+    # Chunk injection
+    # ------------------------------------------------------------------
+
+    def _inject_tags_into_chunks(
+        self, chunks_path: Path, tags: dict[str, Any]
+    ) -> int:
+        """Load chunks.json, inject ``document_tags`` into every chunk's metadata.
+
+        Rewrites the file in-place.
+
+        Returns:
+            Number of chunks updated.
+        """
+        with open(chunks_path, encoding="utf-8") as f:
+            chunks = json.load(f)
+
+        for chunk in chunks:
+            chunk.setdefault("metadata", {})["document_tags"] = tags
+
+        with open(chunks_path, "w", encoding="utf-8") as f:
+            json.dump(chunks, f, indent=2, ensure_ascii=False)
+
+        return len(chunks)
+
+    # ------------------------------------------------------------------
+    # Core tagging
+    # ------------------------------------------------------------------
+
+    async def tag_document(
+        self, pub_id: str, chunks_path: Path
+    ) -> TaggingResult:
+        """Tag a single document and inject tags into its chunks.json.
+
+        Args:
+            pub_id: Publication identifier (used for tracker updates).
+            chunks_path: Absolute path to the document's chunks.json file.
+
+        Returns:
+            TaggingResult with status, tags, and processing info.
+        """
+        start = time.monotonic()
+
+        if self.tracker:
+            try:
+                self.tracker.update_tagging_status(pub_id, TaggingStatus.IN_PROGRESS)
+            except Exception:
+                pass
+
+        title, text, text_source = self._get_text_input(pub_id, chunks_path)
+
+        if not text:
+            error = (
+                "No text available for tagging (no abstract and no chunk samples)"
+            )
+            logger.warning(f"{pub_id}: {error}")
+            if self.tracker:
+                try:
+                    self.tracker.update_tagging_status(
+                        pub_id, TaggingStatus.FAILED, error=error
+                    )
+                except Exception:
+                    pass
+            return TaggingResult(
+                publication_id=pub_id,
+                status=TaggingStatus.FAILED,
+                tags=None,
+                processing_time=time.monotonic() - start,
+                text_source=text_source,
+                error_message=error,
+            )
+
+        prompt = self._build_prompt(title, text)
+        tags = await self._call_llm(prompt)
+
+        if tags is None:
+            error = "LLM failed to return valid tags after 3 attempts"
+            logger.error(f"{pub_id}: {error}")
+            if self.tracker:
+                try:
+                    self.tracker.update_tagging_status(
+                        pub_id, TaggingStatus.FAILED, error=error
+                    )
+                except Exception:
+                    pass
+            return TaggingResult(
+                publication_id=pub_id,
+                status=TaggingStatus.FAILED,
+                tags=None,
+                processing_time=time.monotonic() - start,
+                text_source=text_source,
+                error_message=error,
+            )
+
+        # Inject tags into every chunk
+        try:
+            chunks_tagged = self._inject_tags_into_chunks(chunks_path, tags)
+        except Exception as e:
+            error = f"Failed to inject tags into chunks: {e}"
+            logger.error(f"{pub_id}: {error}")
+            if self.tracker:
+                try:
+                    self.tracker.update_tagging_status(
+                        pub_id, TaggingStatus.FAILED, error=error
+                    )
+                except Exception:
+                    pass
+            return TaggingResult(
+                publication_id=pub_id,
+                status=TaggingStatus.FAILED,
+                tags=tags,
+                processing_time=time.monotonic() - start,
+                text_source=text_source,
+                error_message=error,
+            )
+
+        # Persist tags and update tracker status
+        if self.tracker:
+            try:
+                self.tracker.update_tags(pub_id, tags)
+                self.tracker.update_tagging_status(pub_id, TaggingStatus.TAGGED)
+            except Exception as e:
+                logger.warning(f"Could not update tracker for {pub_id}: {e}")
+
+        logger.info(
+            f"Tagged {pub_id}: {chunks_tagged} chunks updated "
+            f"(source: {text_source}, topics: {tags.get('topics', [])})"
+        )
+        return TaggingResult(
+            publication_id=pub_id,
+            status=TaggingStatus.TAGGED,
+            tags=tags,
+            processing_time=time.monotonic() - start,
+            chunks_tagged=chunks_tagged,
+            text_source=text_source,
+        )
+
+    # ------------------------------------------------------------------
+    # Batch processing
+    # ------------------------------------------------------------------
+
+    async def process_all_documents(
+        self,
+        storage: StorageBase,
+        max_docs: int | None = None,
+        overwrite: bool = False,
+    ) -> list[TaggingResult]:
+        """Tag all untagged documents found in the processed chunks directory.
+
+        A document is considered already tagged when its first chunk has a
+        ``metadata["document_tags"]`` key.  This makes the operation fully
+        idempotent — re-running will skip already-tagged documents unless
+        ``overwrite=True`` is passed.
+
+        Args:
+            storage: Storage backend used to locate chunks.json files.
+            max_docs: Maximum documents to tag (None = all).  When None, the
+                      value is read from ``file_processing.tagging.max_docs``
+                      in the config, then falls back to processing everything.
+            overwrite: When True, re-tag documents that have already been tagged,
+                       replacing their existing ``document_tags`` in chunks.json.
+
+        Returns:
+            List of TaggingResult, one per document processed.
+        """
+        # Resolve limit
+        effective_max = max_docs
+        if effective_max is None:
+            cfg_max = self.config.get("max_docs")
+            if isinstance(cfg_max, int) and cfg_max > 0:
+                effective_max = cfg_max
+
+        # Discover all chunks.json files
+        chunk_relatives = storage.glob("processed/chunks/**/chunks.json")
+        if not chunk_relatives:
+            logger.warning("No chunks.json files found — run text chunker first")
+            return []
+
+        logger.info(f"Found {len(chunk_relatives)} chunk file(s)")
+
+        # Build list of (pub_id, local_path), skipping already-tagged docs
+        to_process: list[tuple[str, Path]] = []
+        already_tagged = 0
+        for rel in chunk_relatives:
+            local_path = storage.get_path(rel)
+            # Path pattern: processed/chunks/documents/{source}/{pub_id}/chunks.json
+            pub_id = Path(rel).parent.name
+
+            try:
+                with open(local_path, encoding="utf-8") as f:
+                    first_chunk = json.load(f)[0]
+                if not overwrite and "document_tags" in first_chunk.get("metadata", {}):
+                    already_tagged += 1
+                    logger.debug(f"Skipping already-tagged document: {pub_id}")
+                    continue
+            except Exception as e:
+                logger.warning(
+                    f"Could not read {local_path} for idempotency check: {e}"
+                )
+
+            to_process.append((pub_id, local_path))
+
+        logger.info(
+            f"{len(to_process)} document(s) need tagging "
+            f"({already_tagged} already tagged, skipped)"
+        )
+
+        # Apply max_docs cap
+        if effective_max is not None and len(to_process) > effective_max:
+            logger.info(
+                f"Limiting to {effective_max} of {len(to_process)} "
+                f"documents (max_docs={effective_max})"
+            )
+            to_process = to_process[:effective_max]
+
+        results: list[TaggingResult] = []
+        for pub_id, chunks_path in to_process:
+            result = await self.tag_document(pub_id, chunks_path)
+            results.append(result)
+
+        return results

--- a/backend/storage/database.py
+++ b/backend/storage/database.py
@@ -106,7 +106,6 @@ def ensure_db_initialized():
     if schema_path.exists():
         init_db(schema_path)
     else:
-        # Just create the SQLModel tables if no schema file
         init_db()
         logger.warning(
             f"Schema file not found at {schema_path}, created tables from SQLModel only"

--- a/backend/storage/etl_metadata_schema.sql
+++ b/backend/storage/etl_metadata_schema.sql
@@ -35,6 +35,12 @@ CREATE TABLE IF NOT EXISTS publication_tracking (
     ingestion_timestamp TIMESTAMP,                            -- When ingestion was completed or failed
     ingestion_attempt_count INTEGER NOT NULL DEFAULT 0,       -- Number of ingestion attempts
 
+    -- Tagging stage
+    tagging_status VARCHAR(20) NOT NULL DEFAULT 'Pending',  -- Pending, Tagged, Failed
+    tagging_timestamp TIMESTAMP,                            -- When tagging was completed or failed
+    tagging_attempt_count INTEGER NOT NULL DEFAULT 0,       -- Number of tagging attempts
+    tags TEXT,                                              -- JSON dict with taxonomy keys (regions, topics, etc.)
+
     -- General tracking
     last_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,  -- Timestamp of last modification
     error_message TEXT,                                         -- Most recent error message (if any)
@@ -43,7 +49,8 @@ CREATE TABLE IF NOT EXISTS publication_tracking (
     CHECK (download_status IN ('Pending', 'In Progress', 'Downloaded', 'Failed')),
     CHECK (processing_status IN ('Pending', 'In Progress', 'Processed', 'OCR_Failed', 'Chunking_Failed', 'Failed')),
     CHECK (embedding_status IN ('Pending', 'In Progress', 'Embedded', 'Failed')),
-    CHECK (ingestion_status IN ('Pending', 'In Progress', 'Ingested', 'Failed'))
+    CHECK (ingestion_status IN ('Pending', 'In Progress', 'Ingested', 'Failed')),
+    CHECK (tagging_status IN ('Pending', 'In Progress', 'Tagged', 'Failed'))
 );
 
 -- Create indexes for efficient querying
@@ -51,6 +58,7 @@ CREATE INDEX IF NOT EXISTS idx_pub_download_status ON publication_tracking(downl
 CREATE INDEX IF NOT EXISTS idx_pub_processing_status ON publication_tracking(processing_status);
 CREATE INDEX IF NOT EXISTS idx_pub_embedding_status ON publication_tracking(embedding_status);
 CREATE INDEX IF NOT EXISTS idx_pub_ingestion_status ON publication_tracking(ingestion_status);
+CREATE INDEX IF NOT EXISTS idx_pub_tagging_status ON publication_tracking(tagging_status);
 CREATE INDEX IF NOT EXISTS idx_pub_last_updated ON publication_tracking(last_updated);
 CREATE INDEX IF NOT EXISTS idx_pub_title ON publication_tracking(title);
 CREATE INDEX IF NOT EXISTS idx_pub_year ON publication_tracking(year);


### PR DESCRIPTION
This pull request introduces a new document tagging stage to the ETL pipeline, enabling automatic metadata tagging of processed documents using an LLM. Tags are enforced via Pydantic structured outputs and written to both the SQLite tracking database and every chunk's metadata, making them available as Qdrant payload filters for downstream RAG retrieval.

## Key Changes

### Document Tagging Pipeline Integration

- Added a new `DocumentTagger` utility (`document_tagger.py`) that classifies each document against a configured taxonomy — regions, topics, document type, and methodology — using OpenAI's `beta.chat.completions.parse()` with a `DocumentTags(BaseModel)` schema. This guarantees the four required fields are always present and correctly typed.
- Tags are written to **two places**: persisted to `publication_tracking.tags` in SQLite and injected into every chunk's `metadata["document_tags"]` in `chunks.json`. The chunk injection is what enables Qdrant payload filtering at query time.
- Text input to the LLM uses an abstract-first strategy, falling back to sampling the first, middle, and last chunks when the abstract is absent or shorter than a configurable minimum. This keeps tagging quality robust even for publications without abstracts.
- The tagger is **idempotent by default**: it skips documents whose first chunk already has a `document_tags` key. A `--overwrite` flag bypasses this check to force re-tagging, which is useful when the taxonomy or model changes.
- Added `_run_document_tagger` async method to `orchestrator.py`, integrating the tagger as a pipeline step between text chunking and embeddings generation.
- Introduced a standalone CLI script `run_document_tagger.py` supporting `--config`, `--max-docs`, and `--overwrite` flags, with structured logging and a summary report.

### Configuration Enhancements

- Added a `file_processing.tagging` block to `config.yaml` with settings for: enabled flag, LLM provider/model/temperature/max_tokens, abstract minimum length, fallback chunk count, and the full taxonomy (regions, topics, document_type, methodology).
- Added a `tagging.max_docs: 10` override to `config.dev.yaml` to limit tagging runs during local development.

### Tracking and Status Model Updates

- Added `TaggingStatus` enum (`Pending`, `In Progress`, `Tagged`, `Failed`) to `tracking.py`.
- Extended `PublicationTracking` with four new fields: `tagging_status`, `tagging_timestamp`, `tagging_attempt_count`, and `tags` (JSON-serialised taxonomy dict).
- Added `update_tagging_status` method to `PublicationTracking` for consistent status updates with automatic timestamping.
- Added four methods to `PublicationTracker`: `update_tagging_status`, `update_tags`, `get_publications_for_tagging`, and `get_publication` — exposing the new tracking fields through the business logic layer.
